### PR TITLE
Updating LitleXmlMapper to make it compatible with PHP 8.1 version.

### DIFF
--- a/litle/sdk/LitleXmlMapper.php
+++ b/litle/sdk/LitleXmlMapper.php
@@ -30,7 +30,7 @@ class LitleXmlMapper
     {
     }
 
-    public function request($request,$hash_config=NULL,$useSimpleXml)
+    public function request($request,$hash_config=NULL,$useSimpleXml=false)
     {
         $response = Communication::httpRequest($request,$hash_config);
         if ($useSimpleXml) {


### PR DESCRIPTION
Adding a fix for - Deprecated: Optional parameter $hash_config declared before required parameter $useSimpleXml is implicitly treated as a required parameter