### PR TITLE
promoting changes for litle php sdk v8.32 and v8.33

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,25 @@
 = LitleOnline CHANGELOG
 
+==version v8.33(October 18, 2023)
+• Change : Added New Enum -foreignRetailerIndicatorEnum with value F .
+• Change : Added New Enum foreignRetailerIndicatorEnum is added in Capture, forceCapture,captureGivenAuth,sale request.
+• Change : Added New Enum -authIndicatorEnum with value Estimated, Incremental.
+• Change : Added new element amount, authIndicator in authorization.
+
+==version V8.32(October 18, 2023)
+• Change : New elements retailerAddress added of type contact in authorization , captureGivenAuth and sale Request.
+• Change : New elements additionalCOFData added of type additionalCOFData in authorization , captureGivenAuth and sale
+request.
+• Change : New elements totalPaymentCount, paymentType, uniqueId,frequencyOfMIT,validationReference, sequenceIndicator are added for new element additionalCOFData
+• Change : Added new elements businessIndicator, merchantCategoryCode, crypto in authorization, captureGivenAuth and sale
+request.
+• Change : Added new subelements SellerId, URL in existing complex type Contact.
+• Change : Added New Enum businessIndicatorEnum with values consumerBillPayment, buyOnlinePickUpInStore,
+highRiskSecuritiesPurchase, fundTransfer, walletTransfer.
+• Change : Added New Enum paymentTypeEnum with values Fixed Amount, Variable Amount.
+• Change : Added New Enum frequencyOfMITEnum with values Daily, Weekly, BiWeekly, Monthly, Quarterly, BiAnnually,
+Annually, UNSCHEDULED.
+
 ==version 8.31.2
 * Feature: phpseclib v8
 

--- a/litle/sdk/LitleOnline.php
+++ b/litle/sdk/LitleOnline.php
@@ -25,8 +25,8 @@
  */
 
 namespace litle\sdk;
-define('CURRENT_XML_VERSION', '8.31');
-define('CURRENT_SDK_VERSION', 'PHP;8.31.0');
+define('CURRENT_XML_VERSION', '8.33');
+define('CURRENT_SDK_VERSION', 'PHP;8.33.0');
 define('MAX_TXNS_PER_BATCH', 100000);
 define('MAX_TXNS_PER_REQUEST', 500000);
 define('LITLE_CONFIG_LIST', 'user,password,merchantId,timeout,proxy,reportGroup,version,url,litle_requests_path,batch_requests_path,sftp_username,sftp_password,batch_url,tcp_port,tcp_ssl,tcp_timeout,print_xml');

--- a/litle/sdk/LitleOnlineRequest.php
+++ b/litle/sdk/LitleOnlineRequest.php
@@ -72,7 +72,9 @@ class LitleOnlineRequest
     public function authorizationRequest($hash_in)
     {
         if (isset($hash_in['litleTxnId'])) {
-            $hash_out = array('litleTxnId' => (XmlFields::returnArrayValue($hash_in, 'litleTxnId')));
+            $hash_out = array('litleTxnId' => (XmlFields::returnArrayValue($hash_in, 'litleTxnId')),
+                'amount' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'amount')),
+                'authIndicator' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'authIndicator')));
         } else {
             $hash_out = array(
                 'orderId' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'orderId')),
@@ -83,6 +85,8 @@ class LitleOnlineRequest
                 'customerInfo' => (XmlFields::customerInfo(XmlFields::returnArrayValue($hash_in, 'customerInfo'))),
                 'billToAddress' => (XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'billToAddress'))),
                 'shipToAddress' => (XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'shipToAddress'))),
+                'retailerAddress' => (XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'retailerAddress'))),
+                'additionalCOFData' => (XmlFields::additionalCOFData(XmlFields::returnArrayValue($hash_in, 'additionalCOFData'))),
                 'card' => (XmlFields::cardType(XmlFields::returnArrayValue($hash_in, 'card'))),
                 'paypal' => (XmlFields::payPal(XmlFields::returnArrayValue($hash_in, 'paypal'))),
                 'token' => (XmlFields::cardTokenType(XmlFields::returnArrayValue($hash_in, 'token'))),
@@ -109,6 +113,10 @@ class LitleOnlineRequest
                 'processingType' => XmlFields::returnArrayValue($hash_in, 'processingType'),
                 'originalNetworkTransactionId' => XmlFields::returnArrayValue($hash_in, 'originalNetworkTransactionId'),
                 'originalTransactionAmount' => XmlFields::returnArrayValue($hash_in, 'originalTransactionAmount'),
+                'merchantCategoryCode' => XmlFields::returnArrayValue($hash_in, 'merchantCategoryCode'),
+                'businessIndicator' => XmlFields::returnArrayValue($hash_in, 'businessIndicator'),
+                'crypto' => XmlFields::returnArrayValue($hash_in, 'crypto'),
+                'authIndicator' => XmlFields::returnArrayValue($hash_in, 'authIndicator')
             );
         }
         $choice_hash = array(XmlFields::returnArrayValue($hash_out, 'card'), XmlFields::returnArrayValue($hash_out, 'paypal'), XmlFields::returnArrayValue($hash_out, 'token'), XmlFields::returnArrayValue($hash_out, 'paypage'), XmlFields::returnArrayValue($hash_out, 'applepay'), XmlFields::returnArrayValue($hash_out, 'mpos'));
@@ -129,6 +137,8 @@ class LitleOnlineRequest
             'customerInfo' => XmlFields::customerInfo(XmlFields::returnArrayValue($hash_in, 'customerInfo')),
             'billToAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'billToAddress')),
             'shipToAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'shipToAddress')),
+            'retailerAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'retailerAddress')),
+            'additionalCOFData' => XmlFields::additionalCOFData(XmlFields::returnArrayValue($hash_in, 'additionalCOFData')),
             'card' => XmlFields::cardType(XmlFields::returnArrayValue($hash_in, 'card')),
             'paypal' => XmlFields::payPal(XmlFields::returnArrayValue($hash_in, 'paypal')),
             'token' => XmlFields::cardTokenType(XmlFields::returnArrayValue($hash_in, 'token')),
@@ -159,6 +169,10 @@ class LitleOnlineRequest
             'processingType' => XmlFields::returnArrayValue($hash_in, 'processingType'),
             'originalNetworkTransactionId' => XmlFields::returnArrayValue($hash_in, 'originalNetworkTransactionId'),
             'originalTransactionAmount' => XmlFields::returnArrayValue($hash_in, 'originalTransactionAmount'),
+            'merchantCategoryCode' => XmlFields::returnArrayValue($hash_in, 'merchantCategoryCode'),
+            'businessIndicator' => XmlFields::returnArrayValue($hash_in, 'businessIndicator'),
+            'crypto' => XmlFields::returnArrayValue($hash_in, 'crypto'),
+            'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'),
         );
 
         $choice_hash = array($hash_out['card'], $hash_out['paypal'], $hash_out['token'], $hash_out['paypage'], $hash_out['applepay'], $hash_out['mpos']);
@@ -252,6 +266,7 @@ class LitleOnlineRequest
             'merchantData' => (XmlFields::merchantData(XmlFields::returnArrayValue($hash_in, 'merchantData'))),
             'debtRepayment' => XmlFields::returnArrayValue($hash_in, 'debtRepayment'),
             'processingType' => XmlFields::returnArrayValue($hash_in, 'processingType'),
+            'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'),
         );
 
         $choice_hash = array(XmlFields::returnArrayValue($hash_out, 'card'), XmlFields::returnArrayValue($hash_out, 'paypal'), XmlFields::returnArrayValue($hash_out, 'token'), XmlFields::returnArrayValue($hash_out, 'paypage'), XmlFields::returnArrayValue($hash_out, 'mpos'));
@@ -270,7 +285,8 @@ class LitleOnlineRequest
             'enhancedData' => XmlFields::enhancedData(XmlFields::returnArrayValue($hash_in, 'enhancedData')),
             'processingInstructions' => XmlFields::processingInstructions(XmlFields::returnArrayValue($hash_in, 'processingInstructions')),
             'payPalOrderComplete' => XmlFields::returnArrayValue($hash_in, 'payPalOrderComplete'),
-            'payPalNotes' => XmlFields::returnArrayValue($hash_in, 'payPalNotes'));
+            'payPalNotes' => XmlFields::returnArrayValue($hash_in, 'payPalNotes'),
+            'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'));
         $captureResponse = $this->processRequest($hash_out, $hash_in, 'capture');
 
         return $captureResponse;
@@ -287,6 +303,8 @@ class LitleOnlineRequest
             'orderSource' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'orderSource')),
             'billToAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'billToAddress')),
             'shipToAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'shipToAddress')),
+            'retailerAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'retailerAddress')),
+            'additionalCOFData' => XmlFields::additionalCOFData(XmlFields::returnArrayValue($hash_in, 'additionalCOFData')),
             'card' => XmlFields::cardType(XmlFields::returnArrayValue($hash_in, 'card')),
             'token' => XmlFields::cardTokenType(XmlFields::returnArrayValue($hash_in, 'token')),
             'paypage' => XmlFields::cardPaypageType(XmlFields::returnArrayValue($hash_in, 'paypage')),
@@ -302,7 +320,11 @@ class LitleOnlineRequest
             'debtRepayment' => XmlFields::returnArrayValue($hash_in, 'debtRepayment'),
             'processingType' => XmlFields::returnArrayValue($hash_in, 'processingType'),
             'originalNetworkTransactionId' => XmlFields::returnArrayValue($hash_in, 'originalNetworkTransactionId'),
-            'originalTransactionAmount' => XmlFields::returnArrayValue($hash_in, 'originalTransactionAmount')
+            'originalTransactionAmount' => XmlFields::returnArrayValue($hash_in, 'originalTransactionAmount'),
+            'merchantCategoryCode' => XmlFields::returnArrayValue($hash_in, 'merchantCategoryCode'),
+            'businessIndicator' => XmlFields::returnArrayValue($hash_in, 'businessIndicator'),
+            'crypto' => XmlFields::returnArrayValue($hash_in, 'crypto'),
+            'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'),
         );
 
         $choice_hash = array($hash_out['card'], $hash_out['token'], $hash_out['paypage'], $hash_out['mpos']);

--- a/litle/sdk/Test/functional/AuthFunctionalTest.php
+++ b/litle/sdk/Test/functional/AuthFunctionalTest.php
@@ -25,6 +25,7 @@
 
 namespace litle\sdk\Test\functional;
 
+use http\Message;
 use litle\sdk\LitleOnlineRequest;
 use litle\sdk\XmlParser;
 
@@ -68,7 +69,7 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
 
     public function test_simple_auth_with_litleTxnId()
     {
-        $hash_in = array('reportGroup' => 'planets', 'litleTxnId' => '1234567891234567891');
+        $hash_in = array('reportGroup' => 'planets', 'litleTxnId' => '1234567891234567891','amount' => '124','authIndicator'=>'Estimated');
 
         $initilaize = new LitleOnlineRequest();
         $authorizationResponse = $initilaize->authorizationRequest($hash_in);
@@ -203,7 +204,7 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
             'orderId' => '2111',
             'orderSource' => 'ecommerce',
             'id' => '654',
-            'amount' => '12312');
+            'amount' => '1231');
 
         $initilaize = new LitleOnlineRequest();
         $authorizationResponse = $initilaize->authorizationRequest($hash_in);
@@ -215,7 +216,7 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
     {
         $hash_in = array(
             'card' => array('type' => 'VI',
-                'number' => '4100200300011001',
+                'number' => '4100200300011000',
                 'expDate' => '0521',),
             'orderId' => '2111',
             'amount' => '4999',
@@ -236,7 +237,7 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
     {
         $hash_in = array(
             'card' => array('type' => 'VI',
-                'number' => '4100200300011001',
+                'number' => '4100200300011000',
                 'expDate' => '0521',
                 'cardValidationNum' => '463',),
             'orderId' => '2111',
@@ -254,7 +255,7 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
     {
         $hash_in = array(
             'card' => array('type' => 'VI',
-                'number' => '4100200300011001',
+                'number' => '4100200300011000',
                 'expDate' => '0521',
                 'cardValidationNum' => '463',),
             'orderId' => '2111',
@@ -263,6 +264,108 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
             'originalNetworkTransactionId' => 'Value from Net_Id1 response',
             'originalTransactionAmount' => '4999',);
 
+        $initilaize = new LitleOnlineRequest();
+        $authorizationResponse = $initilaize->authorizationRequest($hash_in);
+        $response = XmlParser::getNode($authorizationResponse, 'response');
+        $this->assertEquals('000', $response);
+    }
+      public function test_auth_with_v8_32()
+    {
+            $hash_in = array(
+                'card' => array(
+                    'type' => 'VI',
+                    'number' => '4005518220000002',
+                    'expDate' => '0150',
+                    'cardValidationNum' => '987',
+                ),
+                'id'=>'0001',
+                'orderId' => '82364_cnpApiAuth',
+                'amount' => '2870',
+                'orderSource' => 'telephone',
+                'billToAddress' => array(
+                    'name' => 'David Berman A',
+                    'addressLine1' => '10 Main Street',
+                    'city' => 'San Jose',
+                    'state' => 'ca',
+                    'zip' => '95032',
+                    'country' => 'USA',
+                    'email' => 'dberman@phoenixProcessing.com',
+                    'phone' => '781-270-1111',
+                    'sellerId' => '21234234A1',
+                    'url' => 'www.google.com',
+                ),
+                'shipToAddress' => array(
+                    'name' => 'Raymond J. Johnson Jr. B',
+                    'addressLine1' => '123 Main Street',
+                    'city' => 'McLean',
+                    'state' => 'VA',
+                    'zip' => '22102',
+                    'country' => 'USA',
+                    'email' => 'ray@rayjay.com',
+                    'phone' => '978-275-0000',
+                    'sellerId' => '21234234A2',
+                    'url' => 'www.google.com',
+                ),
+                'retailerAddress' => array(
+                    'name' => 'John doe',
+                    'addressLine1' => '123 Main Street',
+                    'addressLine2' => '123 Main Street',
+                    'addressLine3' => '123 Main Street',
+                    'city' => 'Cincinnati',
+                    'state' => 'OH',
+                    'zip' => '45209',
+                    'country' => 'USA',
+                    'email' => 'noone@abc.com',
+                    'phone' => '1234562783',
+                    'sellerId' => '21234234A12345678910',
+                    'companyName' => 'Google INC',
+                    'url' => 'https://www.youtube.com/results?search_query',
+                ),
+                'additionalCOFData' => array(
+                    'totalPaymentCount' => 'ND',
+                    'paymentType' => 'Fixed Amount',
+                    'uniqueId' => '234GTYH654RF13',
+                    'frequencyOfMIT' => 'Annually',
+                    'validationReference' => 'ANBH789UHY564RFC@EDB',
+                    'sequenceIndicator' => '86',
+                ),
+                'merchantCategoryCode' => '5964',
+                'businessIndicator' => 'walletTransfer',
+                'crypto' => 'true',
+            );
+        $initilaize = new LitleOnlineRequest();
+        $authorizationResponse = $initilaize->authorizationRequest($hash_in);
+        $response = XmlParser::getNode($authorizationResponse, 'response');
+        $this->assertEquals('000', $response);
+    }
+
+    public function test_auth_with_changes_v8_33()
+    {
+        $hash_in = array(
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4005518220000002',
+                'expDate' => '0150',
+                'cardValidationNum' => '987',
+            ),
+            'id'=>'0001',
+            'orderId' => '82364_cnpApiAuth',
+            'amount' => '2870',
+            'orderSource' => 'telephone',
+            'additionalCOFData' => array(
+                'totalPaymentCount' => 'ND',
+                'paymentType' => 'Fixed Amount',
+                'uniqueId' => '234GTYH654RF13',
+                'frequencyOfMIT' => 'Annually',
+                'validationReference' => 'ANBH789UHY564RFC@EDB',
+                'sequenceIndicator' => '86',
+            ),
+            'merchantCategoryCode' => '5964',
+            'businessIndicator' => 'walletTransfer',
+            'crypto' => 'true',
+            'authIndicator' => 'Estimated'
+
+        );
         $initilaize = new LitleOnlineRequest();
         $authorizationResponse = $initilaize->authorizationRequest($hash_in);
         $response = XmlParser::getNode($authorizationResponse, 'response');

--- a/litle/sdk/Test/functional/BatchRequestFunctionalTest.php
+++ b/litle/sdk/Test/functional/BatchRequestFunctionalTest.php
@@ -32,7 +32,8 @@ class BatchRequestFunctionalTest extends \PHPUnit_Framework_TestCase
             'orderId'=> '2111',
             'reportGroup'=>'Planets',
             'orderSource'=>'ecommerce',
-            'amount'=>'123');
+            'amount'=>'123',
+            'foreignRetailerIndicator' => 'F');
         $batch_request = new BatchRequest($this->direct);
         $batch_request->addSale($hash_in);
 
@@ -88,7 +89,59 @@ class BatchRequestFunctionalTest extends \PHPUnit_Framework_TestCase
             'orderId'=> '2111',
             'reportGroup'=>'Planets',
             'orderSource'=>'ecommerce',
-            'amount'=>'123');
+            'amount'=>'123',
+            'billToAddress' => array(
+                'name' => 'David Berman A',
+                'addressLine1' => '10 Main Street',
+                'city' => 'San Jose',
+                'state' => 'ca',
+                'zip' => '95032',
+                'country' => 'USA',
+                'email' => 'dberman@phoenixProcessing.com',
+                'phone' => '781-270-1111',
+                'sellerId' => '21234234A1',
+                'url' => 'www.google.com',
+            ),
+            'shipToAddress' => array(
+                'name' => 'Raymond J. Johnson Jr. B',
+                'addressLine1' => '123 Main Street',
+                'city' => 'McLean',
+                'state' => 'VA',
+                'zip' => '22102',
+                'country' => 'USA',
+                'email' => 'ray@rayjay.com',
+                'phone' => '978-275-0000',
+                'sellerId' => '21234234A2',
+                'url' => 'www.google.com',
+            ),
+            'retailerAddress' => array(
+                'name' => 'John doe',
+                'addressLine1' => '123 Main Street',
+                'addressLine2' => '123 Main Street',
+                'addressLine3' => '123 Main Street',
+                'city' => 'Cincinnati',
+                'state' => 'OH',
+                'zip' => '45209',
+                'country' => 'USA',
+                'email' => 'noone@abc.com',
+                'phone' => '1234562783',
+                'sellerId' => '21234234A12345678910',
+                'companyName' => 'Google INC',
+                'url' => 'https://www.youtube.com/results?search_query',
+            ),
+            'additionalCOFData' => array(
+                'totalPaymentCount' => 'ND',
+                'paymentType' => 'Fixed Amount',
+                'uniqueId' => '234GTYH654RF13',
+                'frequencyOfMIT' => 'Annually',
+                'validationReference' => 'ANBH789UHY564RFC@EDB',
+                'sequenceIndicator' => '86',
+            ),
+            'merchantCategoryCode' => '5964',
+            'businessIndicator' => 'walletTransfer',
+            'crypto' => 'true',
+            'authIndicator' => 'Estimated',
+        );
         $batch_request = new BatchRequest($this->direct);
         $batch_request->addAuth($hash_in);
 
@@ -976,6 +1029,26 @@ class BatchRequestFunctionalTest extends \PHPUnit_Framework_TestCase
         $cts = $batch_request->getCountsAndAmounts();
         $this->assertNotNull($cts);
     }
+
+    public function test_auth_with_litleTxnId()
+    {
+        if(strtolower($this->preliveStatus) == 'down'){
+            $this->markTestSkipped('Prelive is not available');
+        }
+
+        $hash_in = array('reportGroup' => 'planets', 'litleTxnId' => '1234567891234567891','authIndicator' => 'Estimated','amount' => '123');
+
+        $batch_request = new BatchRequest($this->direct);
+        $batch_request->addAuth($hash_in);
+
+        $this->assertTrue(file_exists($batch_request->batch_file));
+        $this->assertEquals(1, $batch_request->total_txns);
+
+        $cts = $batch_request->getCountsAndAmounts();
+        $this->assertEquals(1, $cts['auth']['count']);
+        $this->assertEquals(123, $cts['auth']['amount']);
+    }
+
 
     public function tearDown()
     {

--- a/litle/sdk/Test/functional/CaptureFunctionalTest.php
+++ b/litle/sdk/Test/functional/CaptureFunctionalTest.php
@@ -70,4 +70,17 @@ class CaptureFunctionalTest extends \PHPUnit_Framework_TestCase
         $message = XmlParser::getAttribute($captureResponse, 'litleOnlineResponse', 'response');
         $this->assertEquals('0', $message);
     }
+
+    public function test_simple_capture_with_foreignRetailerIndicatorEnum()
+    {
+        $hash_in = array(
+            'litleTxnId' => '1234567891234567891',
+            'amount' => '123',
+            'foreignRetailerIndicator' => 'F');
+
+        $initilaize = new LitleOnlineRequest();
+        $captureResponse = $initilaize->captureRequest($hash_in);
+        $message = XmlParser::getAttribute($captureResponse, 'litleOnlineResponse', 'response');
+        $this->assertEquals('0', $message);
+    }
 }

--- a/litle/sdk/Test/functional/CaptureGivenAuthFunctionalTest.php
+++ b/litle/sdk/Test/functional/CaptureGivenAuthFunctionalTest.php
@@ -134,4 +134,77 @@ class CaptureGivenAuthFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Approved', $message);
     }
 
+    public function test_simple_captureGivenAuth_v8_33()
+    {
+        $hash_in = array(
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4005518220000002',
+                'expDate' => '0150',
+                'cardValidationNum' => '987',
+            ),
+            'id'=>'0001',
+            'orderId' => '82364_cnpApiAuth',
+            'amount' => '2870',
+            'authInformation' => array(
+                'authDate' => '2002-10-09', 'authCode' => '543216',
+                'authAmount' => '12345'),
+            'orderSource' => 'ecommerce',
+            'billToAddress' => array(
+                'name' => 'David Berman A',
+                'addressLine1' => '10 Main Street',
+                'city' => 'San Jose',
+                'state' => 'ca',
+                'zip' => '95032',
+                'country' => 'USA',
+                'email' => 'dberman@phoenixProcessing.com',
+                'phone' => '781-270-1111',
+                'sellerId' => '21234234A1',
+                'url' => 'www.google.com',
+            ),
+            'shipToAddress' => array(
+                'name' => 'Raymond J. Johnson Jr. B',
+                'addressLine1' => '123 Main Street',
+                'city' => 'McLean',
+                'state' => 'VA',
+                'zip' => '22102',
+                'country' => 'USA',
+                'email' => 'ray@rayjay.com',
+                'phone' => '978-275-0000',
+                'sellerId' => '21234234A2',
+                'url' => 'www.google.com',
+            ),
+            'retailerAddress' => array(
+                'name' => 'John doe',
+                'addressLine1' => '123 Main Street',
+                'addressLine2' => '123 Main Street',
+                'addressLine3' => '123 Main Street',
+                'city' => 'Cincinnati',
+                'state' => 'OH',
+                'zip' => '45209',
+                'country' => 'USA',
+                'email' => 'noone@abc.com',
+                'phone' => '1234562783',
+                'sellerId' => '21234234A123456789101112',
+                'companyName' => 'Google INC',
+                'url' => 'https://www.youtube.com/results?search_query',
+            ),
+            'additionalCOFData' => array(
+                'totalPaymentCount' => 'ND',
+                'paymentType' => 'Fixed Amount',
+                'uniqueId' => '234GTYH654RF13',
+                'frequencyOfMIT' => 'Annually',
+                'validationReference' => 'ANBH789UHY564RFC@EDB',
+                'sequenceIndicator' => '86',
+            ),
+            'merchantCategoryCode' => '5964',
+            'businessIndicator' => 'walletTransfer',
+            'crypto' => 'true',
+            'foreignRetailerIndicator' => 'F'
+        );
+        $initilaize = new LitleOnlineRequest();
+        $captureGivenAuthResponse = $initilaize->captureGivenAuthRequest($hash_in);
+        $message = XmlParser::getNode($captureGivenAuthResponse, 'message');
+        $this->assertEquals('Approved', $message);
+    }
 }

--- a/litle/sdk/Test/functional/ForceCaptureFunctionalTest.php
+++ b/litle/sdk/Test/functional/ForceCaptureFunctionalTest.php
@@ -98,4 +98,29 @@ class ForceCaptureFunctionalTest extends \PHPUnit_Framework_TestCase
         $response = XmlParser::getAttribute($forceCaptureResponse, 'litleOnlineResponse', 'response');
         $this->assertEquals('000', $response);
     }
+
+    public function test_simple_forceCapture_with_foreignRetailerIndicatorEnum()
+    {
+        $hash_in = array(
+            'merchantId' => '101',
+            'version' => '8.8',
+            'reportGroup' => 'Planets',
+            'litleTxnId' => '123456',
+            'orderId' => '12344',
+            'amount' => '106',
+            'secondaryAmount' => '2000',
+            'orderSource' => 'ecommerce',
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1210'
+            ),
+            'foreignRetailerIndicator' => 'F'
+        );
+
+        $initilaize = new LitleOnlineRequest();
+        $forceCaptureResponse = $initilaize->forceCaptureRequest($hash_in);
+        $response = XmlParser::getAttribute($forceCaptureResponse, 'litleOnlineResponse', 'response');
+        $this->assertEquals('000', $response);
+    }
 }

--- a/litle/sdk/Test/functional/LitleRequestFunctionalTest.php
+++ b/litle/sdk/Test/functional/LitleRequestFunctionalTest.php
@@ -65,7 +65,7 @@ class LitleRequestFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(file_exists($fn1));
         $this->assertFalse(file_exists($fn2));
 
-        $expected = '<batchRequest merchantId="0180" merchantSdk="PHP;8.31.0" authAmount="0" numAuths="0" saleAmount="123" numSales="1" creditAmount="0" numCredits="0" numTokenRegistrations="0"
+        $expected = '<batchRequest merchantId="0180" merchantSdk="PHP;8.33.0" authAmount="0" numAuths="0" saleAmount="123" numSales="1" creditAmount="0" numCredits="0" numTokenRegistrations="0"
         captureGivenAuthAmount="0" numCaptureGivenAuths="0" forceCaptureAmount="0" numForceCaptures="0" authReversalAmount="0" numAuthReversals="0"
         captureAmount="0" numCaptures="0" echeckVerificationAmount="0" numEcheckVerification="0" echeckCreditAmount="0" numEcheckCredit="0"
         numEcheckRedeposit="0" echeckSalesAmount="0" numEcheckSales="0" numUpdateCardValidationNumOnTokens="0"
@@ -106,7 +106,7 @@ class LitleRequestFunctionalTest extends \PHPUnit_Framework_TestCase
 
         $request->createRFRRequest(array('litleSessionId' => '8675309'));
 
-        $expected = '<litleRequest numBatchRequests="0" version="8.31" xmlns="http://www.litle.com/schema">
+        $expected = '<litleRequest numBatchRequests="0" version="8.33" xmlns="http://www.litle.com/schema">
                     <authentication><user>XXXXXX</user><password>XXXXXX</password></authentication>
                     <RFRRequest><litleSessionId>8675309</litleSessionId></RFRRequest>
                     </litleRequest>';
@@ -151,9 +151,9 @@ class LitleRequestFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(file_exists($fn1));
         $this->assertTrue(file_exists($request->request_file));
 
-        $expected = '<litleRequest numBatchRequests="1" version="8.31" xmlns="http://www.litle.com/schema">
+        $expected = '<litleRequest numBatchRequests="1" version="8.33" xmlns="http://www.litle.com/schema">
         <authentication><user>XXXXX</user><password>XXXXX</password></authentication>
-        <batchRequest merchantId="0180" merchantSdk="PHP;8.31.0" authAmount="0" numAuths="0" saleAmount="123" numSales="1" creditAmount="0" numCredits="0" numTokenRegistrations="0"
+        <batchRequest merchantId="0180" merchantSdk="PHP;8.33.0" authAmount="0" numAuths="0" saleAmount="123" numSales="1" creditAmount="0" numCredits="0" numTokenRegistrations="0"
         captureGivenAuthAmount="0" numCaptureGivenAuths="0" forceCaptureAmount="0" numForceCaptures="0" authReversalAmount="0" numAuthReversals="0"
         captureAmount="0" numCaptures="0" echeckVerificationAmount="0" numEcheckVerification="0" echeckCreditAmount="0" numEcheckCredit="0"
         numEcheckRedeposit="0" echeckSalesAmount="0" numEcheckSales="0" numUpdateCardValidationNumOnTokens="0" numUpdateSubscriptions="0"

--- a/litle/sdk/Test/functional/SaleFunctionalTest.php
+++ b/litle/sdk/Test/functional/SaleFunctionalTest.php
@@ -170,7 +170,7 @@ class aaaaSaleFunctionalTest extends \PHPUnit_Framework_TestCase
             'orderId' => '2111',
             'reportGroup' => 'Planets',
             'orderSource' => 'ecommerce',
-            'amount' => '123');
+            'amount' => '12334');
 
         $initialize = new LitleOnlineRequest();
         $saleResponse = $initialize->saleRequest($hash_in);
@@ -227,7 +227,7 @@ class aaaaSaleFunctionalTest extends \PHPUnit_Framework_TestCase
     {
         $hash_in = array(
             'card' => array('type' => 'VI',
-                'number' => '4100200300011001',
+                'number' => '4100200300011000',
                 'expDate' => '0521',
                 'cardValidationNum' => '463',),
             'orderId' => '2111',
@@ -245,7 +245,7 @@ class aaaaSaleFunctionalTest extends \PHPUnit_Framework_TestCase
     {
         $hash_in = array(
             'card' => array('type' => 'VI',
-                'number' => '4100200300011001',
+                'number' => '4100200300011000',
                 'expDate' => '0521',
                 'cardValidationNum' => '463',),
             'orderId' => '2111',
@@ -258,5 +258,78 @@ class aaaaSaleFunctionalTest extends \PHPUnit_Framework_TestCase
         $saleResponse = $initilaize->saleRequest($hash_in);
         $response = XmlParser::getNode($saleResponse, 'response');
         $this->assertEquals('000', $response);
+    }
+
+    public function test_changes_for_v8_33()
+    {
+        $hash_in = array(
+                'card' => array(
+                    'type' => 'VI',
+                    'number' => '4005518220000002',
+                    'expDate' => '0150',
+                    'cardValidationNum' => '987',
+                ),
+                'id'=>'0001',
+                'orderId' => '82364_cnpApiAuth',
+                'amount' => '2870',
+                'orderSource' => 'telephone',
+                'billToAddress' => array(
+                    'name' => 'David Berman A',
+                    'addressLine1' => '10 Main Street',
+                    'city' => 'San Jose',
+                    'state' => 'ca',
+                    'zip' => '95032',
+                    'country' => 'USA',
+                    'email' => 'dberman@phoenixProcessing.com',
+                    'phone' => '781-270-1111',
+                    'sellerId' => '21234234A1',
+                    'url' => 'www.google.com',
+                ),
+                'shipToAddress' => array(
+                    'name' => 'Raymond J. Johnson Jr. B',
+                    'addressLine1' => '123 Main Street',
+                    'city' => 'McLean',
+                    'state' => 'VA',
+                    'zip' => '22102',
+                    'country' => 'USA',
+                    'email' => 'ray@rayjay.com',
+                    'phone' => '978-275-0000',
+                    'sellerId' => '21234234A2',
+                    'url' => 'www.google.com',
+                ),
+                'retailerAddress' => array(
+                    'name' => 'John doe',
+                    'addressLine1' => '123 Main Street',
+                    'addressLine2' => '123 Main Street',
+                    'addressLine3' => '123 Main Street',
+                    'city' => 'Cincinnati',
+                    'state' => 'OH',
+                    'zip' => '45209',
+                    'country' => 'USA',
+                    'email' => 'noone@abc.com',
+                    'phone' => '1234562783',
+                    'sellerId' => '21234234A123456789101112',
+                    'companyName' => 'Google INC',
+                    'url' => 'https://www.youtube.com/results?search_query',
+                ),
+                'additionalCOFData' => array(
+                    'totalPaymentCount' => 'ND',
+                    'paymentType' => 'Fixed Amount',
+                    'uniqueId' => '234GTYH654RF13',
+                    'frequencyOfMIT' => 'Annually',
+                    'validationReference' => 'ANBH789UHY564RFC@EDB',
+                    'sequenceIndicator' => '86',
+                ),
+                'merchantCategoryCode' => '5964',
+                'businessIndicator' => 'walletTransfer',
+                'crypto' => 'true',
+                'foreignRetailerIndicator' => 'F'
+            );
+
+        $initialize = new LitleOnlineRequest();
+        $saleResponse = $initialize->saleRequest($hash_in);
+        $message = XmlParser::getAttribute($saleResponse, 'litleOnlineResponse', 'message');
+        $message = XmlParser::getNode($saleResponse, 'message');
+        $this->assertEquals('Approved', $message);
     }
 }

--- a/litle/sdk/Test/functional/XmlFieldsFunctionalTest.php
+++ b/litle/sdk/Test/functional/XmlFieldsFunctionalTest.php
@@ -452,4 +452,78 @@ class XmlFieldsFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("Valid Format", $message);
     }
 
+    public function test_auth_with_sellerID_and_url()
+    {
+        $hash_in = array('merchantId' => '101',
+            'version' => '8.32',
+            'reportGroup' => 'Planets',
+            'orderId' => '12344',
+            'amount' => '106',
+            'orderSource' => 'ecommerce',
+                'card' => array(
+                    'type' => 'VI',
+                    'number' => '4005518220000002',
+                    'expDate' => '0150',
+                    'cardValidationNum' => '987',
+                ),
+                'billToAddress' => array(
+                    'name' => 'David Berman A',
+                    'addressLine1' => '10 Main Street',
+                    'city' => 'San Jose',
+                    'state' => 'ca',
+                    'zip' => '95032',
+                    'country' => 'USA',
+                    'email' => 'dberman@phoenixProcessing.com',
+                    'phone' => '781-270-1111',
+                    'sellerId' => '21234234A1',
+                    'url' => 'www.google.com',
+                ),
+                'shipToAddress' => array(
+                    'name' => 'Raymond J. Johnson Jr. B',
+                    'addressLine1' => '123 Main Street',
+                    'city' => 'McLean',
+                    'state' => 'VA',
+                    'zip' => '22102',
+                    'country' => 'USA',
+                    'email' => 'ray@rayjay.com',
+                    'phone' => '978-275-0000',
+                    'sellerId' => '21234234A2',
+                    'url' => 'www.google.com',
+                ),
+                'retailerAddress' => array(
+                    'name' => 'John doe',
+                    'addressLine1' => '123 Main Street',
+                    'addressLine2' => '123 Main Street',
+                    'addressLine3' => '123 Main Street',
+                    'city' => 'Cincinnati',
+                    'state' => 'OH',
+                    'zip' => '45209',
+                    'country' => 'USA',
+                    'email' => 'noone@abc.com',
+                    'phone' => '1234562783',
+                    'sellerId' => '21234234A1234567891011121111111111111111111',
+                    'companyName' => 'Google INC',
+                    'url' => 'https://www.youtube.com/results?search_query1111111111111111',
+                ),
+                'additionalCOFData' => array(
+                    'totalPaymentCount' => 'ND',
+                    'paymentType' => 'Variable Amount',
+                    'uniqueId' => '234GTYH654RF13',
+                    'frequencyOfMIT' => 'Annually',
+                    'validationReference' => 'ANBH789UHY564RFC@EDB',
+                    'sequenceIndicator' => '86',
+                ),
+                'merchantCategoryCode' => '5964',
+                'businessIndicator' => 'walletTransfer',
+                'crypto' => 'true',
+                'foreignRetailerIndicatorEnum' => 'F'
+            );
+
+
+        $initilaize = new LitleOnlineRequest();
+        $authResponse = $initilaize->authorizationRequest($hash_in);
+        $message = XmlParser::getAttribute($authResponse, 'litleOnlineResponse', 'message');
+        $this->assertEquals("Valid Format", $message);
+    }
+
 }

--- a/litle/sdk/Test/unit/AuthUnitTest.php
+++ b/litle/sdk/Test/unit/AuthUnitTest.php
@@ -614,4 +614,75 @@ class AuthUnitTest extends \PHPUnit_Framework_TestCase
         $litleTest->newXML = $mock;
         $litleTest->authorizationRequest($hash_in);
     }
+
+    public function test_auth_with_additionalCOFData()
+    {
+        $hash_in = array(
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4005518220000002',
+                'expDate' => '0150',
+                'cardValidationNum' => '987',
+            ),
+            'id'=>'0001',
+            'orderId' => '82364_cnpApiAuth',
+            'amount' => '2870',
+            'orderSource' => 'telephone',
+            'additionalCOFData' => array(
+                'totalPaymentCount' => 'ND',
+                'paymentType' => 'Fixed Amount',
+                'uniqueId' => '234GTYH654RF13',
+                'frequencyOfMIT' => 'Annually',
+                'validationReference' => 'ANBH789UHY564RFC@EDB',
+                'sequenceIndicator' => '86',
+            ),
+            'merchantCategoryCode' => '5964',
+            'businessIndicator' => 'walletTransfer',
+            'crypto' => 'true',
+        );
+        $mock = $this->getMock('litle\sdk\LitleXmlMapper');
+        $mock
+            ->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<additionalCOFData><totalPaymentCount>ND.*<paymentType>Fixed Amount.*<uniqueId>234GTYH654RF13.*<frequencyOfMIT>Annually.*<validationReference>ANBH789UHY564RFC@EDB.*<sequenceIndicator>86.*/'));
+        $litleTest = new LitleOnlineRequest();
+        $litleTest->newXML = $mock;
+        $litleTest->authorizationRequest($hash_in);
+    }
+
+    public function test_auth_merchantCategoryCode()
+    {
+        $hash_in = array(
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4005518220000002',
+                'expDate' => '0150',
+                'cardValidationNum' => '987',
+            ),
+            'id'=>'0001',
+            'orderId' => '82364_cnpApiAuth',
+            'amount' => '2870',
+            'orderSource' => 'telephone',
+            'additionalCOFData' => array(
+                'totalPaymentCount' => 'ND',
+                'paymentType' => 'Fixed Amount',
+                'uniqueId' => '234GTYH654RF13',
+                'frequencyOfMIT' => 'Annually',
+                'validationReference' => 'ANBH789UHY564RFC@EDB',
+                'sequenceIndicator' => '86',
+            ),
+            'merchantCategoryCode' => '5964',
+            'businessIndicator' => 'walletTransfer',
+            'crypto' => 'true',
+        );
+        $mock = $this->getMock('litle\sdk\LitleXmlMapper');
+        $mock
+            ->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<merchantCategoryCode>5964.*<businessIndicator>walletTransfer.*<crypto>true.*/'));
+
+        $litleTest = new LitleOnlineRequest();
+        $litleTest->newXML = $mock;
+        $litleTest->authorizationRequest($hash_in);
+    }
 }

--- a/litle/sdk/Test/unit/CaptureGivenAuthUnitTest.php
+++ b/litle/sdk/Test/unit/CaptureGivenAuthUnitTest.php
@@ -351,4 +351,73 @@ class CaptureGivenAuthUnitTest extends \PHPUnit_Framework_TestCase
         $litleTest->newXML = $mock;
         $litleTest->captureGivenAuthRequest($hash_in);
     }
+    public function test_auth_with_additionalCOFData()
+    {
+        $hash_in = array(
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4005518220000002',
+                'expDate' => '0150',
+                'cardValidationNum' => '987',
+            ),
+            'id'=>'0001',
+            'orderId' => '82364_cnpApiAuth',
+            'amount' => '2870',
+            'orderSource' => 'telephone',
+            'additionalCOFData' => array(
+                'totalPaymentCount' => 'ND',
+                'paymentType' => 'Fixed Amount',
+                'uniqueId' => '234GTYH654RF13',
+                'frequencyOfMIT' => 'Annually',
+                'validationReference' => 'ANBH789UHY564RFC@EDB',
+                'sequenceIndicator' => '86',
+            ),
+            'merchantCategoryCode' => '5964',
+            'businessIndicator' => 'walletTransfer',
+            'crypto' => 'true',
+        );
+        $mock = $this->getMock('litle\sdk\LitleXmlMapper');
+        $mock
+            ->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<additionalCOFData><totalPaymentCount>ND.*<paymentType>Fixed Amount.*<uniqueId>234GTYH654RF13.*<frequencyOfMIT>Annually.*<validationReference>ANBH789UHY564RFC@EDB.*<sequenceIndicator>86.*/'));
+        $litleTest = new LitleOnlineRequest();
+        $litleTest->newXML = $mock;
+        $litleTest->captureGivenAuthRequest($hash_in);
+    }
+    public function test_auth_merchantCategoryCode()
+    {
+        $hash_in = array(
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4005518220000002',
+                'expDate' => '0150',
+                'cardValidationNum' => '987',
+            ),
+            'id'=>'0001',
+            'orderId' => '82364_cnpApiAuth',
+            'amount' => '2870',
+            'orderSource' => 'telephone',
+            'additionalCOFData' => array(
+                'totalPaymentCount' => 'ND',
+                'paymentType' => 'Fixed Amount',
+                'uniqueId' => '234GTYH654RF13',
+                'frequencyOfMIT' => 'Annually',
+                'validationReference' => 'ANBH789UHY564RFC@EDB',
+                'sequenceIndicator' => '86',
+            ),
+            'merchantCategoryCode' => '5964',
+            'businessIndicator' => 'walletTransfer',
+            'crypto' => 'true',
+            'foreignRetailerIndicator' => 'F'
+        );
+        $mock = $this->getMock('litle\sdk\LitleXmlMapper');
+        $mock
+            ->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<merchantCategoryCode>5964.*<businessIndicator>walletTransfer.*<crypto>true.*<foreignRetailerIndicator>F.*/'));
+        $litleTest = new LitleOnlineRequest();
+        $litleTest->newXML = $mock;
+        $litleTest->captureGivenAuthRequest($hash_in);
+    }
 }

--- a/litle/sdk/Test/unit/CaptureUnitTest.php
+++ b/litle/sdk/Test/unit/CaptureUnitTest.php
@@ -104,4 +104,21 @@ class CaptureUnitTest extends \PHPUnit_Framework_TestCase
         $litleTest->captureRequest($hash_in);
     }
 
+    public function test_capture_with_foreignRetailerIndicator()
+    {
+        $hash_in = array(
+            'litleTxnId' => '1234567891234567891',
+            'amount' => '123',
+            'foreignRetailerIndicator' => 'F');
+
+        $mock = $this->getMock('litle\sdk\LitleXmlMapper');
+        $mock
+            ->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<amount>123<\/amount><foreignRetailerIndicator>F<\/foreignRetailerIndicator>.*/'));
+
+        $litleTest = new LitleOnlineRequest();
+        $litleTest->newXML = $mock;
+        $litleTest->captureRequest($hash_in);
+    }
 }

--- a/litle/sdk/Test/unit/ForceCaptureUnitTest.php
+++ b/litle/sdk/Test/unit/ForceCaptureUnitTest.php
@@ -311,4 +311,32 @@ class ForceCaptureUnitTest extends \PHPUnit_Framework_TestCase
         $litleTest->newXML = $mock;
         $litleTest->forceCaptureRequest($hash_in);
     }
+
+    public function test_forceCapture_with_foreignRetailerIndicator()
+    {
+        $hash_in = array(
+            'merchantId' => '101',
+            'version' => '8.33',
+            'reportGroup' => 'Planets',
+            'litleTxnId' => '123456',
+            'orderId' => '12344',
+            'amount' => '106',
+            'secondaryAmount' => '2000',
+            'orderSource' => 'ecommerce',
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1210'
+            ),
+            'foreignRetailerIndicator' => 'F'
+        );
+        $mock = $this->getMock('litle\sdk\LitleXmlMapper');
+        $mock
+            ->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<foreignRetailerIndicator>F.*/'));
+        $litleTest = new LitleOnlineRequest();
+        $litleTest->newXML = $mock;
+        $litleTest->forceCaptureRequest($hash_in);
+    }
 }

--- a/litle/sdk/Test/unit/LitleOnlineRequestUnitTest.php
+++ b/litle/sdk/Test/unit/LitleOnlineRequestUnitTest.php
@@ -57,7 +57,7 @@ class LitleOnlineRequestUnitTest extends \PHPUnit_Framework_TestCase
         $mock = $this->getMock('litle\sdk\LitleXmlMapper');
         $mock->expects($this->once())
             ->method('request')
-            ->with($this->matchesRegularExpression('/.*merchantSdk="PHP;8.31.0".*/'));
+            ->with($this->matchesRegularExpression('/.*merchantSdk="PHP;8.33.0".*/'));
 
         $litleTest = new LitleOnlineRequest();
         $litleTest->newXML = $mock;

--- a/litle/sdk/Test/unit/SaleUnitTest.php
+++ b/litle/sdk/Test/unit/SaleUnitTest.php
@@ -639,4 +639,73 @@ class SaleUnitTest extends \PHPUnit_Framework_TestCase
         $litleTest->newXML = $mock;
         $litleTest->saleRequest($hash_in);
     }
+    public function test_sale_with_additionalCOFData()
+    {
+        $hash_in = array(
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4005518220000002',
+                'expDate' => '0150',
+                'cardValidationNum' => '987',
+            ),
+            'id'=>'0001',
+            'orderId' => '82364_cnpApiAuth',
+            'amount' => '2870',
+            'orderSource' => 'telephone',
+            'additionalCOFData' => array(
+                'totalPaymentCount' => 'ND',
+                'paymentType' => 'Fixed Amount',
+                'uniqueId' => '234GTYH654RF13',
+                'frequencyOfMIT' => 'Annually',
+                'validationReference' => 'ANBH789UHY564RFC@EDB',
+                'sequenceIndicator' => '86',
+            ),
+            'merchantCategoryCode' => '5964',
+            'businessIndicator' => 'walletTransfer',
+            'crypto' => 'true',
+        );
+        $mock = $this->getMock('litle\sdk\LitleXmlMapper');
+        $mock
+            ->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<additionalCOFData><totalPaymentCount>ND.*<paymentType>Fixed Amount.*<uniqueId>234GTYH654RF13.*<frequencyOfMIT>Annually.*<validationReference>ANBH789UHY564RFC@EDB.*<sequenceIndicator>86.*/'));
+        $litleTest = new LitleOnlineRequest();
+        $litleTest->newXML = $mock;
+        $litleTest->saleRequest($hash_in);
+    }
+    public function test_sale_merchantCategoryCode()
+    {
+        $hash_in = array(
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4005518220000002',
+                'expDate' => '0150',
+                'cardValidationNum' => '987',
+            ),
+            'id'=>'0001',
+            'orderId' => '82364_cnpApiAuth',
+            'amount' => '2870',
+            'orderSource' => 'telephone',
+            'additionalCOFData' => array(
+                'totalPaymentCount' => 'ND',
+                'paymentType' => 'Fixed Amount',
+                'uniqueId' => '234GTYH654RF13',
+                'frequencyOfMIT' => 'Annually',
+                'validationReference' => 'ANBH789UHY564RFC@EDB',
+                'sequenceIndicator' => '86',
+            ),
+            'merchantCategoryCode' => '5964',
+            'businessIndicator' => 'walletTransfer',
+            'crypto' => 'true',
+            'foreignRetailerIndicator' => 'F'
+        );
+        $mock = $this->getMock('litle\sdk\LitleXmlMapper');
+        $mock
+            ->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<merchantCategoryCode>5964.*<businessIndicator>walletTransfer.*<crypto>true.*<foreignRetailerIndicator>F.*/'));
+        $litleTest = new LitleOnlineRequest();
+        $litleTest->newXML = $mock;
+        $litleTest->saleRequest($hash_in);
+    }
 }

--- a/litle/sdk/Test/unit/XmlFieldsTest.php
+++ b/litle/sdk/Test/unit/XmlFieldsTest.php
@@ -470,6 +470,29 @@ class XmlFieldsTest extends \PHPUnit_Framework_TestCase
         $hash_out = XmlFields::contact($hash);
         $this->assertEquals($input, $hash_out["phone"]);
     }
+    public function test_contact_selleID_to_long()
+    {
+        $input = "21234234A12345678910";
+        $hash = array("sellerId" => $input . "1");
+        $hash_out = XmlFields::contact($hash);
+        $this->assertEquals($input, $hash_out["sellerId"]);
+    }
+
+    public function test_contact_url_to_long()
+    {
+        $input = "www.google.com";
+        $hash = array("url" => $input);
+        $hash_out = XmlFields::contact($hash);
+        $this->assertEquals($input, $hash_out["url"]);
+    }
+
+    public function test_additionalCofData_with_sequenceIndicator()
+    {
+        $input = "12";
+        $hash = array("sequenceIndicator" => $input);
+        $hash_out = XmlFields::additionalCOFData($hash);
+        $this->assertEquals($input, $hash_out["sequenceIndicator"]);
+    }
 
     public function test_recurringRequest_full()
     {

--- a/litle/sdk/Transactions.php
+++ b/litle/sdk/Transactions.php
@@ -15,6 +15,8 @@ class Transactions
             'customerInfo' => XmlFields::customerInfo(XmlFields::returnArrayValue($hash_in, 'customerInfo')),
             'billToAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'billToAddress')),
             'shipToAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'shipToAddress')),
+            'retailerAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'retailerAddress')),
+            'additionalCOFData' => XmlFields::additionalCOFData(XmlFields::returnArrayValue($hash_in, 'additionalCOFData')),
             'card' => XmlFields::cardType(XmlFields::returnArrayValue($hash_in, 'card')),
             'paypal' => XmlFields::payPal(XmlFields::returnArrayValue($hash_in, 'paypal')),
             'token' => XmlFields::cardTokenType(XmlFields::returnArrayValue($hash_in, 'token')),
@@ -40,6 +42,10 @@ class Transactions
             'recurringRequest' => XmlFields::recurringRequestType(XmlFields::returnArrayValue($hash_in, 'recurringRequest')),
             'litleInternalRecurringRequest' => XmlFields::litleInternalRecurringRequestType(XmlFields::returnArrayValue($hash_in, 'litleInternalRecurringRequest')),
             'debtRepayment' => XmlFields::returnArrayValue($hash_in, 'debtRepayment'),
+            'merchantCategoryCode' => XmlFields::returnArrayValue($hash_in, 'merchantCategoryCode'),
+            'businessIndicator' => XmlFields::returnArrayValue($hash_in, 'businessIndicator'),
+            'crypto' => XmlFields::returnArrayValue($hash_in, 'crypto'),
+            'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'),
         );
 
         return $hash_out;
@@ -47,41 +53,53 @@ class Transactions
 
     public static function createAuthHash($hash_in)
     {
-        $hash_out = array(
-            'orderId' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'orderId')),
-            'amount' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'amount')),
-            'surchargeAmount' => XmlFields::returnArrayValue($hash_in, 'surchargeAmount'),
-            'secondaryAmount' => XmlFields::returnArrayValue($hash_in, 'secondaryAmount'),
-            'orderSource' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'orderSource')),
-            'customerInfo' => (XmlFields::customerInfo(XmlFields::returnArrayValue($hash_in, 'customerInfo'))),
-            'billToAddress' => (XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'billToAddress'))),
-            'shipToAddress' => (XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'shipToAddress'))),
-            'card' => (XmlFields::cardType(XmlFields::returnArrayValue($hash_in, 'card'))),
-            'paypal' => (XmlFields::payPal(XmlFields::returnArrayValue($hash_in, 'paypal'))),
-            'token' => (XmlFields::cardTokenType(XmlFields::returnArrayValue($hash_in, 'token'))),
-            'paypage' => (XmlFields::cardPaypageType(XmlFields::returnArrayValue($hash_in, 'paypage'))),
-            'applepay' => (XmlFields::applepayType(XmlFields::returnArrayValue($hash_in, 'applepay'))),
-            'billMeLaterRequest' => (XmlFields::billMeLaterRequest(XmlFields::returnArrayValue($hash_in, 'billMeLaterRequest'))),
-            'cardholderAuthentication' => (XmlFields::fraudCheckType(XmlFields::returnArrayValue($hash_in, 'cardholderAuthentication'))),
-            'processingInstructions' => (XmlFields::processingInstructions(XmlFields::returnArrayValue($hash_in, 'processingInstructions'))),
-            'pos' => (XmlFields::pos(XmlFields::returnArrayValue($hash_in, 'pos'))),
-            'customBilling' => (XmlFields::customBilling(XmlFields::returnArrayValue($hash_in, 'customBilling'))),
-            'taxBilling' => (XmlFields::taxBilling(XmlFields::returnArrayValue($hash_in, 'taxBilling'))),
-            'enhancedData' => (XmlFields::enhancedData(XmlFields::returnArrayValue($hash_in, 'enhancedData'))),
-            'amexAggregatorData' => (XmlFields::amexAggregatorData(XmlFields::returnArrayValue($hash_in, 'amexAggregatorData'))),
-            'allowPartialAuth' => XmlFields::returnArrayValue($hash_in, 'allowPartialAuth'),
-            'healthcareIIAS' => (XmlFields::healthcareIIAS(XmlFields::returnArrayValue($hash_in, 'healthcareIIAS'))),
-            'filtering' => (XmlFields::filteringType(XmlFields::returnArrayValue($hash_in, 'filtering'))),
-            'merchantData' => (XmlFields::merchantData(XmlFields::returnArrayValue($hash_in, 'merchantData'))),
-            'recyclingRequest' => (XmlFields::recyclingRequestType(XmlFields::returnArrayValue($hash_in, 'recyclingRequest'))),
-            'fraudFilterOverride' => XmlFields::returnArrayValue($hash_in, 'fraudFilterOverride'),
-            'recurringRequest' => XmlFields::recurringRequestType(XmlFields::returnArrayValue($hash_in, 'recurringRequest')),
-            'debtRepayment' => XmlFields::returnArrayValue($hash_in, 'debtRepayment'),
-            'processingType' => XmlFields::returnArrayValue($hash_in, 'processingType'),
-            'originalNetworkTransactionId' => XmlFields::returnArrayValue($hash_in, 'originalNetworkTransactionId'),
-            'originalTransactionAmount' => XmlFields::returnArrayValue($hash_in, 'originalTransactionAmount'),
-        );
-
+        if (isset($hash_in['litleTxnId'])) {
+            $hash_out = array(
+                'litleTxnId' => (XmlFields::returnArrayValue($hash_in, 'litleTxnId')),
+                'amount' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'amount')),
+                'authIndicator' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'authIndicator')));
+        } else {
+            $hash_out = array(
+                'orderId' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'orderId')),
+                'amount' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'amount')),
+                'surchargeAmount' => XmlFields::returnArrayValue($hash_in, 'surchargeAmount'),
+                'secondaryAmount' => XmlFields::returnArrayValue($hash_in, 'secondaryAmount'),
+                'orderSource' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'orderSource')),
+                'customerInfo' => (XmlFields::customerInfo(XmlFields::returnArrayValue($hash_in, 'customerInfo'))),
+                'billToAddress' => (XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'billToAddress'))),
+                'shipToAddress' => (XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'shipToAddress'))),
+                'retailerAddress' => (XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'retailerAddress'))),
+                'additionalCOFData' => (XmlFields::additionalCOFData(XmlFields::returnArrayValue($hash_in, 'additionalCOFData'))),
+                'card' => (XmlFields::cardType(XmlFields::returnArrayValue($hash_in, 'card'))),
+                'paypal' => (XmlFields::payPal(XmlFields::returnArrayValue($hash_in, 'paypal'))),
+                'token' => (XmlFields::cardTokenType(XmlFields::returnArrayValue($hash_in, 'token'))),
+                'paypage' => (XmlFields::cardPaypageType(XmlFields::returnArrayValue($hash_in, 'paypage'))),
+                'applepay' => (XmlFields::applepayType(XmlFields::returnArrayValue($hash_in, 'applepay'))),
+                'billMeLaterRequest' => (XmlFields::billMeLaterRequest(XmlFields::returnArrayValue($hash_in, 'billMeLaterRequest'))),
+                'cardholderAuthentication' => (XmlFields::fraudCheckType(XmlFields::returnArrayValue($hash_in, 'cardholderAuthentication'))),
+                'processingInstructions' => (XmlFields::processingInstructions(XmlFields::returnArrayValue($hash_in, 'processingInstructions'))),
+                'pos' => (XmlFields::pos(XmlFields::returnArrayValue($hash_in, 'pos'))),
+                'customBilling' => (XmlFields::customBilling(XmlFields::returnArrayValue($hash_in, 'customBilling'))),
+                'taxBilling' => (XmlFields::taxBilling(XmlFields::returnArrayValue($hash_in, 'taxBilling'))),
+                'enhancedData' => (XmlFields::enhancedData(XmlFields::returnArrayValue($hash_in, 'enhancedData'))),
+                'amexAggregatorData' => (XmlFields::amexAggregatorData(XmlFields::returnArrayValue($hash_in, 'amexAggregatorData'))),
+                'allowPartialAuth' => XmlFields::returnArrayValue($hash_in, 'allowPartialAuth'),
+                'healthcareIIAS' => (XmlFields::healthcareIIAS(XmlFields::returnArrayValue($hash_in, 'healthcareIIAS'))),
+                'filtering' => (XmlFields::filteringType(XmlFields::returnArrayValue($hash_in, 'filtering'))),
+                'merchantData' => (XmlFields::merchantData(XmlFields::returnArrayValue($hash_in, 'merchantData'))),
+                'recyclingRequest' => (XmlFields::recyclingRequestType(XmlFields::returnArrayValue($hash_in, 'recyclingRequest'))),
+                'fraudFilterOverride' => XmlFields::returnArrayValue($hash_in, 'fraudFilterOverride'),
+                'recurringRequest' => XmlFields::recurringRequestType(XmlFields::returnArrayValue($hash_in, 'recurringRequest')),
+                'debtRepayment' => XmlFields::returnArrayValue($hash_in, 'debtRepayment'),
+                'processingType' => XmlFields::returnArrayValue($hash_in, 'processingType'),
+                'originalNetworkTransactionId' => XmlFields::returnArrayValue($hash_in, 'originalNetworkTransactionId'),
+                'originalTransactionAmount' => XmlFields::returnArrayValue($hash_in, 'originalTransactionAmount'),
+                'merchantCategoryCode' => XmlFields::returnArrayValue($hash_in, 'merchantCategoryCode'),
+                'businessIndicator' => XmlFields::returnArrayValue($hash_in, 'businessIndicator'),
+                'crypto' => XmlFields::returnArrayValue($hash_in, 'crypto'),
+                'authIndicator' => XmlFields::returnArrayValue($hash_in, 'authIndicator')
+            );
+       }
         return $hash_out;
     }
 
@@ -161,6 +179,7 @@ class Transactions
             'merchantData' => (XmlFields::merchantData(XmlFields::returnArrayValue($hash_in, 'merchantData'))),
             'debtRepayment' => XmlFields::returnArrayValue($hash_in, 'debtRepayment'),
             'processingType' => XmlFields::returnArrayValue($hash_in, 'processingType'),
+            'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'),
         );
 
         return $hash_out;
@@ -176,8 +195,8 @@ class Transactions
             'enhancedData' => XmlFields::enhancedData(XmlFields::returnArrayValue($hash_in, 'enhancedData')),
             'processingInstructions' => XmlFields::processingInstructions(XmlFields::returnArrayValue($hash_in, 'processingInstructions')),
             'payPalOrderComplete' => XmlFields::returnArrayValue($hash_in, 'payPalOrderComplete'),
-            'payPalNotes' => XmlFields::returnArrayValue($hash_in, 'payPalNotes'));
-
+            'payPalNotes' => XmlFields::returnArrayValue($hash_in, 'payPalNotes'),
+            'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'));
         return $hash_out;
     }
 
@@ -192,6 +211,8 @@ class Transactions
             'orderSource' => Checker::requiredField(XmlFields::returnArrayValue($hash_in, 'orderSource')),
             'billToAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'billToAddress')),
             'shipToAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'shipToAddress')),
+            'retailerAddress' => XmlFields::contact(XmlFields::returnArrayValue($hash_in, 'retailerAddress')),
+            'additionalCOFData' => XmlFields::additionalCOFData(XmlFields::returnArrayValue($hash_in, 'additionalCOFData')),
             'card' => XmlFields::cardType(XmlFields::returnArrayValue($hash_in, 'card')),
             'token' => XmlFields::cardTokenType(XmlFields::returnArrayValue($hash_in, 'token')),
             'paypage' => XmlFields::cardPaypageType(XmlFields::returnArrayValue($hash_in, 'paypage')),
@@ -207,6 +228,10 @@ class Transactions
             'processingType' => XmlFields::returnArrayValue($hash_in, 'processingType'),
             'originalNetworkTransactionId' => XmlFields::returnArrayValue($hash_in, 'originalNetworkTransactionId'),
             'originalTransactionAmount' => XmlFields::returnArrayValue($hash_in, 'originalTransactionAmount'),
+            'merchantCategoryCode' => XmlFields::returnArrayValue($hash_in, 'merchantCategoryCode'),
+            'businessIndicator' => XmlFields::returnArrayValue($hash_in, 'businessIndicator'),
+            'crypto' => XmlFields::returnArrayValue($hash_in, 'crypto'),
+            'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'),
         );
 
         return $hash_out;

--- a/litle/sdk/XmlFields.php
+++ b/litle/sdk/XmlFields.php
@@ -55,7 +55,9 @@ class XmlFields
                 "zip" => XmlFields::returnArrayValue($hash_in, "zip", 20),
                 "country" => XmlFields::returnArrayValue($hash_in, "country", 3),
                 "email" => XmlFields::returnArrayValue($hash_in, "email", 100),
-                "phone" => XmlFields::returnArrayValue($hash_in, "phone", 20)
+                "phone" => XmlFields::returnArrayValue($hash_in, "phone", 20),
+                "sellerId" => XmlFields::returnArrayValue($hash_in, "sellerId", 20),
+                "url" => XmlFields::returnArrayValue($hash_in, "url", 35)
             );
 
             return $hash_out;
@@ -290,6 +292,24 @@ class XmlFields
             return $hash_out;
         }
     }
+
+    public static function additionalCOFData($hash_in)
+    {
+        if (isset($hash_in)) {
+            $hash_out = array(
+                "totalPaymentCount" => XmlFields::returnArrayValue($hash_in, "totalPaymentCount", 2),
+                "paymentType" => XmlFields::returnArrayValue($hash_in, "paymentType"),
+                "uniqueId" => XmlFields::returnArrayValue($hash_in, "uniqueId", 14),
+                "frequencyOfMIT" => XmlFields::returnArrayValue($hash_in, "frequencyOfMIT"),
+                "validationReference" => XmlFields::returnArrayValue($hash_in, "validationReference", 20),
+                "sequenceIndicator" => XmlFields::returnArrayValue($hash_in, "sequenceIndicator"),
+            );
+
+            return $hash_out;
+        }
+
+    }
+
 
     public static function cardType($hash_in)
     {


### PR DESCRIPTION
ChangeLog for V8.32
• Change : New elements retailerAddress added of type contact in authorization , captureGivenAuth and sale Request.
• Change : New elements additionalCOFData added of type additionalCOFData in authorization , captureGivenAuth and sale
request.
• Change : New elements totalPaymentCount, paymentType, uniqueId,frequencyOfMIT,validationReference, sequenceIndicator are added for new element additionalCOFData
• Change : Added new elements businessIndicator, merchantCategoryCode, crypto in authorization, captureGivenAuth and sale
request.
• Change : Added new subelements SellerId, URL in existing complex type Contact.
• Change : Added New Enum businessIndicatorEnum with values consumerBillPayment, buyOnlinePickUpInStore,
highRiskSecuritiesPurchase, fundTransfer, walletTransfer.
• Change : Added New Enum paymentTypeEnum with values Fixed Amount, Variable Amount.
• Change : Added New Enum frequencyOfMITEnum with values Daily, Weekly, BiWeekly, Monthly, Quarterly, BiAnnually,
Annually, UNSCHEDULED.

ChangeLog for v8.33
• Change : Added New Enum -foreignRetailerIndicatorEnum with value F .
• Change : Added New Enum foreignRetailerIndicatorEnum is added in Capture, forceCapture,captureGivenAuth,sale request.
• Change : Added New Enum -authIndicatorEnum with value Estimated, Incremental.
• Change : Added new element amount, authIndicator in authorization,